### PR TITLE
Support for vmware

### DIFF
--- a/vagrant-deb8-fs3/Vagrantfile
+++ b/vagrant-deb8-fs3/Vagrantfile
@@ -1,6 +1,7 @@
-# Debian 8 with branch FREESIDE_3_BRANCH
+# Install Debian 8 with branch FREESIDE_3_BRANCH
+
 Vagrant.configure('2') do |config|
-    config.vm.box = 'debian/contrib-jessie64'
+    config.vm.box = 'bento/debian-8.7'
     config.vm.hostname = 'vagrant-deb8-fs3.lab'
 
     config.vm.network "public_network", ip: "192.168.1.52"
@@ -8,6 +9,10 @@ Vagrant.configure('2') do |config|
     config.vm.provider "virtualbox" do |v|
         v.memory = 4096
         v.cpus = 2
+    end
+    config.vm.provider "vmware_desktop" do |v|
+      v.vmx["memsize"] = 4096
+      v.vmx["numvcpus"] = 2
     end
 
     config.vm.provision :init, type: "shell", path: "provision/initial.sh"

--- a/vagrant-deb8-fs4/Vagrantfile
+++ b/vagrant-deb8-fs4/Vagrantfile
@@ -1,13 +1,18 @@
-# Install Debian 9 with Freeside 4
+# Install Debian 8 with Freeside 4
 
 Vagrant.configure('2') do |config|
-    config.vm.box = 'debian/contrib-jessie64'
+    config.vm.box = 'bento/debian-8.7'
     config.vm.hostname = 'vagrant-deb8-fs4.lab'
 
     config.vm.network "public_network", ip: "192.168.1.50"
+
     config.vm.provider "virtualbox" do |v|
         v.memory = 4096
         v.cpus = 2
+    end
+    config.vm.provider "vmware_desktop" do |v|
+      v.vmx["memsize"] = 4096
+      v.vmx["numvcpus"] = 2
     end
 
     config.vm.provision :init, type: "shell", path: "provision/initial.sh"

--- a/vagrant-deb8-master/Vagrantfile
+++ b/vagrant-deb8-master/Vagrantfile
@@ -1,13 +1,18 @@
-# Install Debian 9 with Freeside 4
+# Install Debian 8 with Freeside 4
 
 Vagrant.configure('2') do |config|
-    config.vm.box = 'debian/contrib-jessie64'
+    config.vm.box = 'bento/debian-8.7'
     config.vm.hostname = 'vagrant-deb8-master.lab'
 
     config.vm.network "public_network", ip: "192.168.1.51"
+
     config.vm.provider "virtualbox" do |v|
         v.memory = 4096
         v.cpus = 2
+    end
+    config.vm.provider "vmware_desktop" do |v|
+      v.vmx["memsize"] = 4096
+      v.vmx["numvcpus"] = 2
     end
 
     config.vm.provision :init, type: "shell", path: "provision/initial.sh"

--- a/vagrant-deb9-fs3/Vagrantfile
+++ b/vagrant-deb9-fs3/Vagrantfile
@@ -1,13 +1,18 @@
-# Install Debian 9 with Freeside 4
+# Install Debian 9 with branch FREESIDE_3_BRANCH
 
 Vagrant.configure('2') do |config|
-    config.vm.box = 'debian/contrib-jessie64'
+    config.vm.box = 'bento/debian-9'
     config.vm.hostname = 'vagrant-deb9-fs3.lab'
 
     config.vm.network "public_network", ip: "192.168.1.54"
+
     config.vm.provider "virtualbox" do |v|
         v.memory = 4096
         v.cpus = 2
+    end
+    config.vm.provider "vmware_desktop" do |v|
+      v.vmx["memsize"] = 4096
+      v.vmx["numvcpus"] = 2
     end
 
     config.vm.provision :init, type: "shell", path: "provision/initial.sh"

--- a/vagrant-deb9-fs4/Vagrantfile
+++ b/vagrant-deb9-fs4/Vagrantfile
@@ -1,13 +1,18 @@
 # Install Debian 9 with Freeside 4
 
 Vagrant.configure('2') do |config|
-    config.vm.box = 'debian/contrib-jessie64'
+    config.vm.box = 'bento/debian-9'
     config.vm.hostname = 'vagrant-deb9-fs4.lab'
 
     config.vm.network "public_network", ip: "192.168.1.53"
+
     config.vm.provider "virtualbox" do |v|
         v.memory = 4096
         v.cpus = 2
+    end
+    config.vm.provider "vmware_desktop" do |v|
+      v.vmx["memsize"] = 4096
+      v.vmx["numvcpus"] = 2
     end
 
     config.vm.provision :init, type: "shell", path: "provision/initial.sh"

--- a/vagrant-deb9-master/Vagrantfile
+++ b/vagrant-deb9-master/Vagrantfile
@@ -1,13 +1,18 @@
 # Install Debian 9 with Freeside 4
 
 Vagrant.configure('2') do |config|
-    config.vm.box = 'debian/contrib-jessie64'
+    config.vm.box = 'bento/debian-9'
     config.vm.hostname = 'vagrant-deb9-master.lab'
 
     config.vm.network "public_network", ip: "192.168.1.55"
+
     config.vm.provider "virtualbox" do |v|
         v.memory = 4096
         v.cpus = 2
+    end
+    config.vm.provider "vmware_desktop" do |v|
+      v.vmx["memsize"] = 4096
+      v.vmx["numvcpus"] = 2
     end
 
     config.vm.provision :init, type: "shell", path: "provision/initial.sh"


### PR DESCRIPTION
* Adds new provider section mimicking the virtualbox but using
the corresponding vmware-specific options.

* Uses bento/debian-* box as the previous debian/ variants only
supports the virtualbox provider.

Note that the debian-9 setup does not work due to a problem
towards the end of the setup with apache2 (as mentioned in IRC).